### PR TITLE
Add proper swagger ui url

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ end
 
 ### Customizing the swagger-ui ###
 
-The swagger-ui provides several options for customizing it's behavior, all of which are documented here https://github.com/swagger-api/swagger-ui#swaggerui. If you need to tweak these or customize the overall look and feel of your swagger-ui, then you'll need to provide your own version of index.html. You can do this with the following generator.
+The swagger-ui provides several options for customizing it's behavior, all of which are documented here https://github.com/swagger-api/swagger-ui/tree/2.x#swaggerui. If you need to tweak these or customize the overall look and feel of your swagger-ui, then you'll need to provide your own version of index.html. You can do this with the following generator.
 
 ```ruby
 rails g rswag:ui:custom


### PR DESCRIPTION
As this only supports swagger ui 2, the url should link accordingly